### PR TITLE
Feature add docker compose for dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+./demo/Dockerfile
+./docker-compose.yml
+node_modules
+./dist

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ Add following `office` and `express` config to `src/server/config.js` file of OS
 
 The office application is available in Office Menu of the OS.js :tada:
 
+## Quick development with docker-compose
+
+Run the following command to run `Collabora`, `OSJS` and `osjs-office-collabora` together:
+
+```bash
+docker compose up -d
+```
+
+Be advised to change the `collabora_online_URL` and `osjs_URL` environments inside `docker-compose.yml` based on your local IP address.
+
+After that the containers are up and running, you can access `OSJS` using your local IP address and the port specified (default 8000) like below:
+
+```
+http://<ip>:8000
+```
+
+Be advised to change `<ip>` with your own local IP address. In addition, every change to the `osjs-office-collabora` results in webpack build and server restart which makes it a very good choice for developing package inside the `OSJS` environment.
+
 ## Quick installation of CODE docker
 
 1- Grab the Docker image

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -2,8 +2,6 @@ FROM osjs/osjs
 
 WORKDIR /usr/src/osjs
 
-RUN npm i ip
-
 COPY ./package.json ./src/packages/osjs-office-collabora/package.json
 RUN cd ./src/packages/osjs-office-collabora && npm i
 

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,18 @@
+FROM osjs/osjs
+
+WORKDIR /usr/src/osjs
+
+RUN npm i ip
+
+COPY ./package.json ./src/packages/osjs-office-collabora/package.json
+RUN cd ./src/packages/osjs-office-collabora && npm i
+
+COPY ./demo/start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+COPY . ./src/packages/osjs-office-collabora/
+RUN cd ./src/packages/osjs-office-collabora && npm run build
+
+RUN npm run package:discover
+
+CMD ["./start.sh"]

--- a/demo/config.js
+++ b/demo/config.js
@@ -1,0 +1,50 @@
+/*
+ * OS.js - JavaScript Cloud/Web Desktop Platform
+ *
+ * Copyright (c) 2011-2020, Anders Evenrud <andersevenrud@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author  Anders Evenrud <andersevenrud@gmail.com>
+ * @licence Simplified BSD License
+ */
+
+//
+// This is the server configuration tree.
+// Guide: https://manual.os-js.org/config/#server
+// Complete config tree: https://github.com/os-js/osjs-server/blob/master/src/config.js
+//
+
+const path = require('path');
+const root = path.resolve(__dirname, '../../');
+
+module.exports = {
+  root,
+  port: 8000,
+  public: path.resolve(root, 'dist'),
+  express:{
+    maxBodySize:'1000000kb'
+  },
+  office: {
+    collabora_online: 'http://192.168.1.103:9980'
+  },
+};

--- a/demo/config.js
+++ b/demo/config.js
@@ -45,6 +45,6 @@ module.exports = {
     maxBodySize:'1000000kb'
   },
   office: {
-    collabora_online: 'http://192.168.1.103:9980'
+    collabora_online: process.env.collabora_online_URL
   },
 };

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -1,0 +1,2 @@
+(cd ./src/packages/osjs-office-collabora && npm run watch) \
+& (npx nodemon --watch package-lock.json --watch src/server --watch package.json --watch src/packages src/server/index.js)

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -1,2 +1,2 @@
 (cd ./src/packages/osjs-office-collabora && npm run watch) \
-& (npx nodemon --watch package-lock.json --watch src/server --watch package.json --watch src/packages src/server/index.js)
+& (npx nodemon --ignore 'dist/**/*' --watch package-lock.json --watch src/server --watch package.json --watch src/packages src/server/index.js)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+#
+# OS.js - JavaScript Cloud/Web Desktop Platform
+#
+# Copyright (c) 2011-2020, Anders Evenrud <andersevenrud@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# @author  Anders Evenrud <andersevenrud@gmail.com>
+# @licence Simplified BSD License
+#
+
+# THIS IS ONLY INTENDED FOR DEVELOPMENT USAGE
+
+version: '3'
+
+services:
+  osjs:
+    build:
+      context: .
+      dockerfile: ./demo/Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/usr/src/osjs/src/packages/osjs-office-collabora
+      - ./demo/config.js:/usr/src/osjs/src/server/config.js
+      - /usr/src/osjs/src/packages/osjs-office-collabora/node_modules
+    environment:
+      - collabora_online=http://192.168.1.103:9980
+      - osjs=http://192.168.1.103:8000
+  collabora:
+    image: "collabora/code"
+    ports:
+      - "9980:9980"
+    environment:
+      - extra_params=--o:ssl.enable=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
       - ./demo/config.js:/usr/src/osjs/src/server/config.js
       - /usr/src/osjs/src/packages/osjs-office-collabora/node_modules
     environment:
-      - collabora_online=http://192.168.1.103:9980
-      - osjs=http://192.168.1.103:8000
+      - collabora_online_URL=http://192.168.1.103:9980
+      - osjs_URL=http://192.168.1.103:8000
   collabora:
     image: "collabora/code"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,4 @@
-#
-# OS.js - JavaScript Cloud/Web Desktop Platform
-#
-# Copyright (c) 2011-2020, Anders Evenrud <andersevenrud@gmail.com>
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-# @author  Anders Evenrud <andersevenrud@gmail.com>
-# @licence Simplified BSD License
-#
-
-# THIS IS ONLY INTENDED FOR DEVELOPMENT USAGE
+# This is only for development
 
 version: '3'
 

--- a/package.json
+++ b/package.json
@@ -53,26 +53,28 @@
     "dist/"
   ],
   "dependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "http": "0.0.1-security",
-    "https": "^1.0.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
+    "http": "0.0.1-security",
+    "https": "^1.0.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "stream": "0.0.2",
     "url-loader": "^4.1.1",
     "xmldom": "^0.6.0",
-    "xpath": "0.0.32",
-    "@fortawesome/fontawesome-svg-core": "^1.2.35",
-    "@fortawesome/free-solid-svg-icons": "^5.15.3",
-    "@fortawesome/react-fontawesome": "^0.1.14"
+    "xpath": "0.0.32"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0",
     "@osjs/dev-meta": "^1.0.3",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.30.0",
-    "eslint-plugin-react": "^7.24.0"
+    "eslint-plugin-react": "^7.24.0",
+    "webpack": "^4.46.0",
+    "webpack-cli": "^4.10.0"
   },
   "author": "Mahsa Shadi <mahsa.shadi@mail.um.ac.ir>",
   "license": "BSD-2-Clause",

--- a/wopi.js
+++ b/wopi.js
@@ -109,7 +109,7 @@ async function checkFileInfo({req, res, vfs}) {
       UserCanWrite: true,
       // UserCanNotWriteRelative: false,  // to show Save As button
       SupportsUpdate: true,
-      PostMessageOrigin: 'http://192.168.1.144:8000',
+      PostMessageOrigin: process.env.osjs,
     });
   } catch (err) {
     console.log(err);

--- a/wopi.js
+++ b/wopi.js
@@ -109,7 +109,7 @@ async function checkFileInfo({req, res, vfs}) {
       UserCanWrite: true,
       // UserCanNotWriteRelative: false,  // to show Save As button
       SupportsUpdate: true,
-      PostMessageOrigin: process.env.osjs,
+      PostMessageOrigin: process.env.osjs_URL,
     });
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Hi,

In this PR, I have used `docker-compose` to make it easier to develop the package inside `OSJS`. It also helps others to see a demo easily by running only one command.